### PR TITLE
Resolve Node 16 deprecation warnings in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub actions are throwing deprecation warnings due to the use of Node.js 16 in `actions/setup-node@v3` [[recent example]](https://github.com/stac-extensions/cmip6/actions/runs/8643755780):

> [!Warning]
>
> **deploy**
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.


This PR updates `actions/setup-node` to v4.